### PR TITLE
Fix various lint warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_return, clippy::upper_case_acronyms)]
+
 use parking_lot::RwLock;
 use std::fs;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -9,7 +11,6 @@ use std::{
 use futures::join;
 use log::info;
 use structopt::StructOpt;
-use tokio;
 use warp::Filter;
 
 mod crypto;

--- a/src/onion_requests.rs
+++ b/src/onion_requests.rs
@@ -65,7 +65,7 @@ fn parse_onion_request_payload(
     }
     // Extract the different components
     // This is safe because we know blob has a length of at least 4 bytes
-    let size = as_le_u32(&blob[0..4].try_into().unwrap()) as usize;
+    let size = u32::from_le_bytes(blob[0..4].try_into().unwrap()) as usize;
     let ciphertext: Vec<u8> = blob[4..(4 + size)].try_into().unwrap();
     let utf8_json: Vec<u8> = blob[(4 + size)..].try_into().unwrap();
     // Parse JSON
@@ -117,13 +117,4 @@ async fn encrypt_response(response: Response, symmetric_key: &[u8]) -> Result<Re
     let response =
         warp::http::Response::builder().status(StatusCode::OK.as_u16()).body(json).into_response();
     return Ok(response);
-}
-
-// Utilities
-
-fn as_le_u32(array: &[u8; 4]) -> u32 {
-    ((array[0] as u32) << 00)
-        + ((array[1] as u32) << 08)
-        + ((array[2] as u32) << 16)
-        + ((array[3] as u32) << 24)
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -31,9 +31,9 @@ pub async fn handle_rpc_call(rpc_call: RpcCall) -> Result<Response, Rejection> {
     // Adding "http://placeholder.io" in front of the endpoint is a workaround
     // for the fact that the URL crate doesn't accept relative URLs. There are
     // other (cleaner) ways to fix this but they tend to be much more complex.
-    let raw_uri = format!("http://placeholder.io/{}", rpc_call.endpoint.trim_start_matches("/"));
+    let raw_uri = format!("http://placeholder.io/{}", rpc_call.endpoint.trim_start_matches('/'));
     let path: String = match raw_uri.parse::<http::Uri>() {
-        Ok(uri) => uri.path().trim_start_matches("/").to_string(),
+        Ok(uri) => uri.path().trim_start_matches('/').to_string(),
         Err(e) => {
             warn!("Couldn't parse URI from: {} due to error: {}.", &raw_uri, e);
             return Err(warp::reject::custom(Error::InvalidRpcCall));
@@ -85,7 +85,7 @@ async fn handle_get_request(
         return Ok(warp::reply::json(&response).into_response());
     } else if path.starts_with("rooms") {
         reject_if_file_server_mode(path)?;
-        let components: Vec<&str> = path.split("/").collect(); // Split on subsequent slashes
+        let components: Vec<&str> = path.split('/').collect(); // Split on subsequent slashes
         if components.len() == 1 {
             return handlers::get_all_rooms();
         } else if components.len() == 2 {
@@ -102,7 +102,7 @@ async fn handle_get_request(
     // This route requires auth in open group server mode, but not in file server mode
     let pool = get_pool_for_room(&rpc_call)?;
     if path.starts_with("files") {
-        let components: Vec<&str> = path.split("/").collect(); // Split on subsequent slashes
+        let components: Vec<&str> = path.split('/').collect(); // Split on subsequent slashes
         if components.len() != 2 {
             warn!("Invalid endpoint: {}.", rpc_call.endpoint);
             return Err(warp::reject::custom(Error::InvalidRpcCall));
@@ -119,7 +119,7 @@ async fn handle_get_request(
             .map(|json| warp::reply::json(&json).into_response());
     }
     // Handle routes that require authorization
-    let auth_token = auth_token.ok_or(warp::reject::custom(Error::NoAuthToken))?;
+    let auth_token = auth_token.ok_or_else(|| warp::reject::custom(Error::NoAuthToken))?;
     match path {
         "messages" => {
             reject_if_file_server_mode(path)?;
@@ -211,10 +211,10 @@ async fn handle_post_request(
         return handlers::store_file(room_id, &json.file, auth_token, &pool).await;
     }
     // Handle routes that require authorization
-    let auth_token = auth_token.ok_or(warp::reject::custom(Error::NoAuthToken))?;
+    let auth_token = auth_token.ok_or_else(|| warp::reject::custom(Error::NoAuthToken))?;
     if path.starts_with("rooms") {
         reject_if_file_server_mode(path)?;
-        let components: Vec<&str> = path.split("/").collect(); // Split on subsequent slashes
+        let components: Vec<&str> = path.split('/').collect(); // Split on subsequent slashes
         if components.len() == 3 && components[2] == "image" {
             #[derive(Debug, Deserialize)]
             struct JSON {
@@ -315,11 +315,11 @@ async fn handle_delete_request(
     pool: &storage::DatabaseConnectionPool,
 ) -> Result<Response, Rejection> {
     // Check that the auth token is present
-    let auth_token = auth_token.ok_or(warp::reject::custom(Error::NoAuthToken))?;
+    let auth_token = auth_token.ok_or_else(|| warp::reject::custom(Error::NoAuthToken))?;
     // DELETE /messages/:server_id
     if path.starts_with("messages") {
         reject_if_file_server_mode(path)?;
-        let components: Vec<&str> = path.split("/").collect(); // Split on subsequent slashes
+        let components: Vec<&str> = path.split('/').collect(); // Split on subsequent slashes
         if components.len() != 2 {
             warn!("Invalid endpoint: {}.", path);
             return Err(warp::reject::custom(Error::InvalidRpcCall));
@@ -336,7 +336,7 @@ async fn handle_delete_request(
     // DELETE /block_list/:public_key
     if path.starts_with("block_list") {
         reject_if_file_server_mode(path)?;
-        let components: Vec<&str> = path.split("/").collect(); // Split on subsequent slashes
+        let components: Vec<&str> = path.split('/').collect(); // Split on subsequent slashes
         if components.len() != 2 {
             warn!("Invalid endpoint: {}.", path);
             return Err(warp::reject::custom(Error::InvalidRpcCall));
@@ -352,7 +352,7 @@ async fn handle_delete_request(
     // DELETE /moderators/:public_key
     if path.starts_with("moderators") {
         reject_if_file_server_mode(path)?;
-        let components: Vec<&str> = path.split("/").collect(); // Split on subsequent slashes
+        let components: Vec<&str> = path.split('/').collect(); // Split on subsequent slashes
         if components.len() != 2 {
             warn!("Invalid endpoint: {}.", path);
             return Err(warp::reject::custom(Error::InvalidRpcCall));

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -258,7 +258,7 @@ pub async fn prune_files(file_expiration: i64) {
             Ok(query) => query,
             Err(e) => return error!("Couldn't prune files due to error: {}.", e),
         };
-        let rows = match query.query_map(params![expiration], |row| Ok(row.get(0)?)) {
+        let rows = match query.query_map(params![expiration], |row| row.get(0)) {
             Ok(rows) => rows,
             Err(e) => {
                 return error!("Couldn't prune files due to error: {}.", e);
@@ -300,7 +300,7 @@ fn get_all_room_ids() -> Result<Vec<String>, Error> {
     // Query the database
     let raw_query = format!("SELECT id FROM {}", MAIN_TABLE);
     let mut query = conn.prepare(&raw_query).map_err(|_| Error::DatabaseFailedInternally)?;
-    let rows = match query.query_map(params![], |row| Ok(row.get(0)?)) {
+    let rows = match query.query_map(params![], |row| row.get(0)) {
         Ok(rows) => rows,
         Err(e) => {
             error!("Couldn't query database due to error: {}.", e);


### PR DESCRIPTION
- Ran `cargo-clippy` to get some free code improvements. Some of the relevant issues fixed were:
https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call
https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern
https://rust-lang.github.io/rust-clippy/master/index.html#needless_question_mark
- replaced `as_le_u32` with a standard library one

Would be good to add clippy as part of the CI pipeline. Added a statement in main.rs to disable some of the more opinionated warnings, so currently `cargo-clippy` passes with no warnings.