### PR TITLE
Remove table name globals

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -361,8 +361,7 @@ pub fn get_auth_token_challenge(
     // Note that a given public key can have multiple pending tokens
     let conn = pool.get().map_err(|_| Error::DatabaseFailedInternally)?;
     let now = chrono::Utc::now().timestamp();
-    let stmt =
-        "INSERT INTO pending_tokens (public_key, timestamp, token) VALUES (?1, ?2, ?3)";
+    let stmt = "INSERT INTO pending_tokens (public_key, timestamp, token) VALUES (?1, ?2, ?3)";
     let _ = match conn.execute(&stmt, params![hex_public_key, now, token]) {
         Ok(rows) => rows,
         Err(e) => {
@@ -404,8 +403,7 @@ pub fn claim_auth_token(
         .ok_or(Error::Unauthorized)?;
     let token = &pending_tokens[index].1;
     // Store the claimed token
-    let stmt =
-        "INSERT INTO tokens (public_key, timestamp, token) VALUES (?1, ?2, ?3)";
+    let stmt = "INSERT INTO tokens (public_key, timestamp, token) VALUES (?1, ?2, ?3)";
     let now = chrono::Utc::now().timestamp();
     match conn.execute(&stmt, params![public_key, now, hex::encode(token)]) {
         Ok(_) => (),
@@ -606,8 +604,7 @@ fn update_usage_statistics(
     let public_key = get_public_key_for_auth_token(auth_token, pool)?;
     let conn = pool.get().map_err(|_| Error::DatabaseFailedInternally)?;
     let now = chrono::Utc::now().timestamp();
-    let stmt =
-        "INSERT OR REPLACE INTO user_activity (public_key, last_active) VALUES(?1, ?2)";
+    let stmt = "INSERT OR REPLACE INTO user_activity (public_key, last_active) VALUES(?1, ?2)";
     conn.execute(&stmt, params![public_key, now]).map_err(|_| Error::DatabaseFailedInternally)?;
     return Ok(());
 }
@@ -676,8 +673,7 @@ pub fn delete_message(
     };
     // Update the deletions table if needed
     if count > 0 {
-        let stmt =
-            "INSERT INTO deleted_messages (deleted_message_id) VALUES (?1)";
+        let stmt = "INSERT INTO deleted_messages (deleted_message_id) VALUES (?1)";
         match tx.execute(&stmt, params![id]) {
             Ok(_) => (),
             Err(e) => {
@@ -723,7 +719,8 @@ pub fn get_deleted_messages(
     if query_params.get("from_server_id").is_some() {
         raw_query = "SELECT id, deleted_message_id FROM deleted_messages WHERE id > (?1) ORDER BY id ASC LIMIT (?2)";
     } else {
-        raw_query = "SELECT id, deleted_message_id FROM deleted_messages ORDER BY id DESC LIMIT (?2)";
+        raw_query =
+            "SELECT id, deleted_message_id FROM deleted_messages ORDER BY id DESC LIMIT (?2)";
     }
     let mut query = conn.prepare(raw_query).map_err(|_| Error::DatabaseFailedInternally)?;
     let rows = match query.query_map(params![from_server_id, limit], |row| {
@@ -846,8 +843,7 @@ pub fn ban_and_delete_all_messages(
     ban(public_key, auth_token, pool)?;
     // Get the IDs of the messages to delete
     let conn = pool.get().map_err(|_| Error::DatabaseFailedInternally)?;
-    let raw_query =
-        "SELECT id FROM messages WHERE public_key = (?1) AND is_deleted = 0";
+    let raw_query = "SELECT id FROM messages WHERE public_key = (?1) AND is_deleted = 0";
     let mut query = conn.prepare(&raw_query).map_err(|_| Error::DatabaseFailedInternally)?;
     let rows = match query.query_map(params![public_key], |row| Ok(row.get(0)?)) {
         Ok(rows) => rows,
@@ -1259,8 +1255,7 @@ fn is_banned(public_key: &str, pool: &storage::DatabaseConnectionPool) -> Result
     // Get a database connection
     let conn = pool.get().map_err(|_| Error::DatabaseFailedInternally)?;
     // Query the database
-    let raw_query =
-        "SELECT COUNT(public_key) FROM block_list WHERE public_key = (?1)";
+    let raw_query = "SELECT COUNT(public_key) FROM block_list WHERE public_key = (?1)";
     let mut query = conn.prepare(&raw_query).map_err(|_| Error::DatabaseFailedInternally)?;
     let rows = match query.query_map(params![public_key], |row| row.get(0)) {
         Ok(rows) => rows,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -136,7 +136,7 @@ pub async fn store_file(
     pool: &storage::DatabaseConnectionPool,
 ) -> Result<Response, Rejection> {
     // It'd be nice to use the UUID crate for the file ID, but clients want an integer ID
-    const UPPER_BOUND: u64 = 2u64.pow(53); // JS has trouble if we go higher than this
+    const UPPER_BOUND: u64 = 1u64 << 53; // JS has trouble if we go higher than this
     let id: u64 = thread_rng().gen_range(0..UPPER_BOUND);
     let now = chrono::Utc::now().timestamp();
     // Check authorization level if needed

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -14,8 +14,6 @@ pub type DatabaseConnectionPool = r2d2::Pool<SqliteConnectionManager>;
 
 // Main
 
-pub const MAIN_TABLE: &str = "main";
-
 lazy_static::lazy_static! {
 
     pub static ref MAIN_POOL: DatabaseConnectionPool = {
@@ -32,14 +30,12 @@ pub fn create_main_database_if_needed() {
 }
 
 fn create_main_tables_if_needed(conn: &DatabaseConnection) {
-    let main_table_cmd = format!(
-        "CREATE TABLE IF NOT EXISTS {} (
+    let main_table_cmd =
+        "CREATE TABLE IF NOT EXISTS main (
         id TEXT PRIMARY KEY,
         name TEXT,
         image_id TEXT
-    )",
-        MAIN_TABLE
-    );
+    )";
     conn.execute(&main_table_cmd, params![]).expect("Couldn't create main table.");
 }
 
@@ -48,15 +44,6 @@ fn create_main_tables_if_needed(conn: &DatabaseConnection) {
 pub const PENDING_TOKEN_EXPIRATION: i64 = 10 * 60;
 pub const TOKEN_EXPIRATION: i64 = 7 * 24 * 60 * 60;
 pub const FILE_EXPIRATION: i64 = 15 * 24 * 60 * 60;
-
-pub const MESSAGES_TABLE: &str = "messages";
-pub const DELETED_MESSAGES_TABLE: &str = "deleted_messages";
-pub const MODERATORS_TABLE: &str = "moderators";
-pub const BLOCK_LIST_TABLE: &str = "block_list";
-pub const PENDING_TOKENS_TABLE: &str = "pending_tokens";
-pub const TOKENS_TABLE: &str = "tokens";
-pub const FILES_TABLE: &str = "files";
-pub const USER_ACTIVITY_TABLE: &str = "user_activity";
 
 lazy_static::lazy_static! {
 
@@ -87,84 +74,68 @@ pub fn create_room_tables_if_needed(conn: &DatabaseConnection) {
     // Messages
     // The `id` field is needed to make `rowid` stable, which is important because otherwise
     // the `id`s in this table won't correspond to those in the deleted messages table
-    let messages_table_cmd = format!(
-        "CREATE TABLE IF NOT EXISTS {} (
+    let messages_table_cmd =
+        "CREATE TABLE IF NOT EXISTS messages (
         id INTEGER PRIMARY KEY,
         public_key TEXT,
         timestamp INTEGER,
         data TEXT,
         signature TEXT,
         is_deleted INTEGER
-    )",
-        MESSAGES_TABLE
-    );
+    )";
     conn.execute(&messages_table_cmd, params![]).expect("Couldn't create messages table.");
     // Deleted messages
-    let deleted_messages_table_cmd = format!(
-        "CREATE TABLE IF NOT EXISTS {} (
+    let deleted_messages_table_cmd =
+        "CREATE TABLE IF NOT EXISTS deleted_messages (
         id INTEGER PRIMARY KEY,
         deleted_message_id INTEGER
-    )",
-        DELETED_MESSAGES_TABLE
-    );
+    )";
     conn.execute(&deleted_messages_table_cmd, params![])
         .expect("Couldn't create deleted messages table.");
     // Moderators
-    let moderators_table_cmd = format!(
-        "CREATE TABLE IF NOT EXISTS {} (
+    let moderators_table_cmd =
+        "CREATE TABLE IF NOT EXISTS moderators (
         public_key TEXT
-    )",
-        MODERATORS_TABLE
-    );
+    )";
     conn.execute(&moderators_table_cmd, params![]).expect("Couldn't create moderators table.");
     // Block list
-    let block_list_table_cmd = format!(
-        "CREATE TABLE IF NOT EXISTS {} (
+    let block_list_table_cmd =
+        "CREATE TABLE IF NOT EXISTS block_list (
         public_key TEXT
-    )",
-        BLOCK_LIST_TABLE
-    );
+    )";
     conn.execute(&block_list_table_cmd, params![]).expect("Couldn't create block list table.");
     // Pending tokens
     // Note that a given public key can have multiple pending tokens
-    let pending_tokens_table_cmd = format!(
-        "CREATE TABLE IF NOT EXISTS {} (
+    let pending_tokens_table_cmd =
+        "CREATE TABLE IF NOT EXISTS pending_tokens (
         public_key TEXT,
         timestamp INTEGER,
         token BLOB
-    )",
-        PENDING_TOKENS_TABLE
-    );
+    )";
     conn.execute(&pending_tokens_table_cmd, params![])
         .expect("Couldn't create pending tokens table.");
     // Tokens
     // The token is stored as hex here (rather than as bytes) because it's more convenient for lookup
-    let tokens_table_cmd = format!(
-        "CREATE TABLE IF NOT EXISTS {} (
+    let tokens_table_cmd =
+        "CREATE TABLE IF NOT EXISTS tokens (
         public_key TEXT,
         timestamp INTEGER,
         token TEXT PRIMARY KEY
-    )",
-        TOKENS_TABLE
-    );
+    )";
     conn.execute(&tokens_table_cmd, params![]).expect("Couldn't create tokens table.");
     // Files
-    let files_table_cmd = format!(
-        "CREATE TABLE IF NOT EXISTS {} (
+    let files_table_cmd =
+        "CREATE TABLE IF NOT EXISTS files (
         id TEXT PRIMARY KEY,
         timestamp INTEGER
-    )",
-        FILES_TABLE
-    );
+    )";
     conn.execute(&files_table_cmd, params![]).expect("Couldn't create files table.");
     // User activity table
-    let user_activity_table_cmd = format!(
-        "CREATE TABLE IF NOT EXISTS {} (
+    let user_activity_table_cmd =
+        "CREATE TABLE IF NOT EXISTS user_activity (
         public_key TEXT PRIMARY KEY,
         last_active INTEGER NOT NULL
-    )",
-        USER_ACTIVITY_TABLE,
-    );
+    )";
     conn.execute(&user_activity_table_cmd, params![])
         .expect("Couldn't create user activity table.");
 }
@@ -213,7 +184,7 @@ async fn prune_tokens() {
             Ok(conn) => conn,
             Err(e) => return error!("Couldn't prune tokens due to error: {}.", e),
         };
-        let stmt = format!("DELETE FROM {} WHERE timestamp < (?1)", TOKENS_TABLE);
+        let stmt = "DELETE FROM tokens WHERE timestamp < (?1)";
         let now = chrono::Utc::now().timestamp();
         let expiration = now - TOKEN_EXPIRATION;
         match conn.execute(&stmt, params![expiration]) {
@@ -236,7 +207,7 @@ async fn prune_pending_tokens() {
             Ok(conn) => conn,
             Err(e) => return error!("Couldn't prune pending tokens due to error: {}.", e),
         };
-        let stmt = format!("DELETE FROM {} WHERE timestamp < (?1)", PENDING_TOKENS_TABLE);
+        let stmt = "DELETE FROM pending_tokens WHERE timestamp < (?1)";
         let now = chrono::Utc::now().timestamp();
         let expiration = now - PENDING_TOKEN_EXPIRATION;
         match conn.execute(&stmt, params![expiration]) {
@@ -257,7 +228,7 @@ fn get_expired_file_ids(
         error!("Couldn't get database connection to prune files due to error: {}.", e);
     })?;
     // Get the IDs of the files to delete
-    let raw_query = format!("SELECT id FROM {} WHERE timestamp < (?1)", FILES_TABLE);
+    let raw_query = "SELECT id FROM files WHERE timestamp < (?1)";
 
     let mut query = conn.prepare(&raw_query).map_err(|e| {
         error!("Couldn't prepare query to prune files due to error: {}.", e);
@@ -311,7 +282,7 @@ pub async fn prune_files_for_room(pool: &DatabaseConnectionPool, room: &str, fil
             // Remove the file records from the database
             // FIXME: It'd be great to do this in a single statement, but apparently this is not supported very well
             for id in ids {
-                let stmt = format!("DELETE FROM {} WHERE id = (?1)", FILES_TABLE);
+                let stmt = "DELETE FROM files WHERE id = (?1)";
                 match conn.execute(&stmt, params![id]) {
                     Ok(_) => (),
                     Err(e) => {
@@ -355,14 +326,12 @@ pub fn perform_migration() {
             return error!("Couldn't get all room IDs.");
         }
     };
-    let create_tokens_table_cmd = format!(
-        "CREATE TABLE IF NOT EXISTS {} (
+    let create_tokens_table_cmd =
+        "CREATE TABLE IF NOT EXISTS tokens (
         public_key TEXT,
         timestamp INTEGER,
         token TEXT PRIMARY KEY
-    )",
-        TOKENS_TABLE
-    );
+    )";
     let migrations =
         Migrations::new(vec![M::up("DROP TABLE tokens"), M::up(&create_tokens_table_cmd)]);
     for room in rooms {
@@ -379,7 +348,7 @@ fn get_all_room_ids() -> Result<Vec<String>, Error> {
     // Get a database connection
     let conn = MAIN_POOL.get().map_err(|_| Error::DatabaseFailedInternally)?;
     // Query the database
-    let raw_query = format!("SELECT id FROM {}", MAIN_TABLE);
+    let raw_query = "SELECT id FROM main";
     let mut query = conn.prepare(&raw_query).map_err(|_| Error::DatabaseFailedInternally)?;
     let rows = match query.query_map(params![], |row| row.get(0)) {
         Ok(rows) => rows,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -30,8 +30,7 @@ pub fn create_main_database_if_needed() {
 }
 
 fn create_main_tables_if_needed(conn: &DatabaseConnection) {
-    let main_table_cmd =
-        "CREATE TABLE IF NOT EXISTS main (
+    let main_table_cmd = "CREATE TABLE IF NOT EXISTS main (
         id TEXT PRIMARY KEY,
         name TEXT,
         image_id TEXT
@@ -74,8 +73,7 @@ pub fn create_room_tables_if_needed(conn: &DatabaseConnection) {
     // Messages
     // The `id` field is needed to make `rowid` stable, which is important because otherwise
     // the `id`s in this table won't correspond to those in the deleted messages table
-    let messages_table_cmd =
-        "CREATE TABLE IF NOT EXISTS messages (
+    let messages_table_cmd = "CREATE TABLE IF NOT EXISTS messages (
         id INTEGER PRIMARY KEY,
         public_key TEXT,
         timestamp INTEGER,
@@ -85,29 +83,25 @@ pub fn create_room_tables_if_needed(conn: &DatabaseConnection) {
     )";
     conn.execute(&messages_table_cmd, params![]).expect("Couldn't create messages table.");
     // Deleted messages
-    let deleted_messages_table_cmd =
-        "CREATE TABLE IF NOT EXISTS deleted_messages (
+    let deleted_messages_table_cmd = "CREATE TABLE IF NOT EXISTS deleted_messages (
         id INTEGER PRIMARY KEY,
         deleted_message_id INTEGER
     )";
     conn.execute(&deleted_messages_table_cmd, params![])
         .expect("Couldn't create deleted messages table.");
     // Moderators
-    let moderators_table_cmd =
-        "CREATE TABLE IF NOT EXISTS moderators (
+    let moderators_table_cmd = "CREATE TABLE IF NOT EXISTS moderators (
         public_key TEXT
     )";
     conn.execute(&moderators_table_cmd, params![]).expect("Couldn't create moderators table.");
     // Block list
-    let block_list_table_cmd =
-        "CREATE TABLE IF NOT EXISTS block_list (
+    let block_list_table_cmd = "CREATE TABLE IF NOT EXISTS block_list (
         public_key TEXT
     )";
     conn.execute(&block_list_table_cmd, params![]).expect("Couldn't create block list table.");
     // Pending tokens
     // Note that a given public key can have multiple pending tokens
-    let pending_tokens_table_cmd =
-        "CREATE TABLE IF NOT EXISTS pending_tokens (
+    let pending_tokens_table_cmd = "CREATE TABLE IF NOT EXISTS pending_tokens (
         public_key TEXT,
         timestamp INTEGER,
         token BLOB
@@ -116,23 +110,20 @@ pub fn create_room_tables_if_needed(conn: &DatabaseConnection) {
         .expect("Couldn't create pending tokens table.");
     // Tokens
     // The token is stored as hex here (rather than as bytes) because it's more convenient for lookup
-    let tokens_table_cmd =
-        "CREATE TABLE IF NOT EXISTS tokens (
+    let tokens_table_cmd = "CREATE TABLE IF NOT EXISTS tokens (
         public_key TEXT,
         timestamp INTEGER,
         token TEXT PRIMARY KEY
     )";
     conn.execute(&tokens_table_cmd, params![]).expect("Couldn't create tokens table.");
     // Files
-    let files_table_cmd =
-        "CREATE TABLE IF NOT EXISTS files (
+    let files_table_cmd = "CREATE TABLE IF NOT EXISTS files (
         id TEXT PRIMARY KEY,
         timestamp INTEGER
     )";
     conn.execute(&files_table_cmd, params![]).expect("Couldn't create files table.");
     // User activity table
-    let user_activity_table_cmd =
-        "CREATE TABLE IF NOT EXISTS user_activity (
+    let user_activity_table_cmd = "CREATE TABLE IF NOT EXISTS user_activity (
         public_key TEXT PRIMARY KEY,
         last_active INTEGER NOT NULL
     )";
@@ -326,8 +317,7 @@ pub fn perform_migration() {
             return error!("Couldn't get all room IDs.");
         }
     };
-    let create_tokens_table_cmd =
-        "CREATE TABLE IF NOT EXISTS tokens (
+    let create_tokens_table_cmd = "CREATE TABLE IF NOT EXISTS tokens (
         public_key TEXT,
         timestamp INTEGER,
         token TEXT PRIMARY KEY

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -89,7 +89,7 @@ async fn test_file_handling() {
     .unwrap();
     // Check that there's a file record
     let conn = pool.get().unwrap();
-    let raw_query = format!("SELECT id FROM {}", storage::FILES_TABLE);
+    let raw_query = "SELECT id FROM files";
     let id_as_string: String =
         conn.query_row(&raw_query, params![], |row| Ok(row.get(0)?)).unwrap();
     let id = id_as_string.parse::<u64>().unwrap();
@@ -107,7 +107,7 @@ async fn test_file_handling() {
     fs::read(format!("files/{}_files/{}", test_room_id, id)).unwrap_err();
     // Check that the file record is also gone
     let conn = pool.get().unwrap();
-    let raw_query = format!("SELECT id FROM {}", storage::FILES_TABLE);
+    let raw_query = "SELECT id FROM files";
     let result: Result<String, _> = conn.query_row(&raw_query, params![], |row| Ok(row.get(0)?));
     // It should be gone now
     result.unwrap_err();


### PR DESCRIPTION
These make the code more complex and make the the queries harder to read.

(A bit of history, since I was a dev way back when this became a Big Deal: configurable table names is an antipattern that stemmed from old PHP (or similar) web hosts that came with a single MySQL database requiring you use different prefixes to load multiple instances of code into the same database.  Without insane mysql configurations, prefix configurability is an antipattern that just results in less readable code.)

Also a one-line fix here that lets the program work on slightly older rust compiler versions.